### PR TITLE
 Fix UGE/ULT/ULE/UGT implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+lib/friscjs-browser.min.js

--- a/lib/friscjs-browser.js
+++ b/lib/friscjs-browser.js
@@ -3937,9 +3937,9 @@ var FRISC = function() {
         result = !!(this._getFlag(this._f.N));
       } else if (cond === '_NN/P') {    // ******** NN,P        N=0
         result = !(this._getFlag(this._f.N));
-      } else if (cond === '_C/ULT') {   // ******** C,ULT       C=1
+      } else if (cond === '_C/UGE') {   // ******** C,UGE       C=1
         result = !!(this._getFlag(this._f.C));
-      } else if (cond === '_NC/UGE') {  // ******** NC,UGE      C=0
+      } else if (cond === '_NC/ULT') {  // ******** NC,ULT      C=0
         result = !(this._getFlag(this._f.C));
       } else if (cond === '_V') {       // ******** V           V=1
         result = !!(this._getFlag(this._f.V));
@@ -3949,11 +3949,11 @@ var FRISC = function() {
         result = !!(this._getFlag(this._f.Z));
       } else if (cond === '_NZ/NE') {   // ******** NZ,NE       Z=0
         result = !(this._getFlag(this._f.Z));
-      } else if (cond === '_ULE') {     // ******** ULE         C=1 ili Z=1
-        result = !!(this._getFlag(this._f.C)) ||
-                 !!(this._getFlag(this._f.Z));
-      } else if (cond === '_UGT') {     // ******** UGT         C=0 i Z=0
+      } else if (cond === '_ULE') {     // ******** ULE         C=0 ili Z=1
         result = !(this._getFlag(this._f.C)) ||
+                 !!(this._getFlag(this._f.Z));
+      } else if (cond === '_UGT') {     // ******** UGT         C=1 i Z=0
+        result = !!(this._getFlag(this._f.C)) &&
                  !(this._getFlag(this._f.Z));
       } else if (cond === '_SLT') {     // ******** SLT         (N xor V)=1
         result = !!(this._getFlag(this._f.N)) !==

--- a/src/friscsim.js
+++ b/src/friscsim.js
@@ -314,9 +314,9 @@ var FRISC = function() {
         result = !!(this._getFlag(this._f.N));
       } else if (cond === '_NN/P') {    // ******** NN,P        N=0
         result = !(this._getFlag(this._f.N));
-      } else if (cond === '_C/ULT') {   // ******** C,ULT       C=1
+      } else if (cond === '_C/UGE') {   // ******** C,UGE       C=1
         result = !!(this._getFlag(this._f.C));
-      } else if (cond === '_NC/UGE') {  // ******** NC,UGE      C=0
+      } else if (cond === '_NC/ULT') {  // ******** NC,ULT      C=0
         result = !(this._getFlag(this._f.C));
       } else if (cond === '_V') {       // ******** V           V=1
         result = !!(this._getFlag(this._f.V));
@@ -326,11 +326,11 @@ var FRISC = function() {
         result = !!(this._getFlag(this._f.Z));
       } else if (cond === '_NZ/NE') {   // ******** NZ,NE       Z=0
         result = !(this._getFlag(this._f.Z));
-      } else if (cond === '_ULE') {     // ******** ULE         C=1 ili Z=1
-        result = !!(this._getFlag(this._f.C)) ||
-                 !!(this._getFlag(this._f.Z));
-      } else if (cond === '_UGT') {     // ******** UGT         C=0 i Z=0
+      } else if (cond === '_ULE') {     // ******** ULE         C=0 ili Z=1
         result = !(this._getFlag(this._f.C)) ||
+                 !!(this._getFlag(this._f.Z));
+      } else if (cond === '_UGT') {     // ******** UGT         C=1 i Z=0
+        result = !!(this._getFlag(this._f.C)) &&
                  !(this._getFlag(this._f.Z));
       } else if (cond === '_SLT') {     // ******** SLT         (N xor V)=1
         result = !!(this._getFlag(this._f.N)) !==

--- a/tests/cpu-tests.js
+++ b/tests/cpu-tests.js
@@ -46,8 +46,8 @@ var tests = [
     T.assertEquals(simulator.CPU._testCond(""), true);
     T.assertEquals(simulator.CPU._testCond("_N/M"), false);
     T.assertEquals(simulator.CPU._testCond("_NN/P"), true);
-    T.assertEquals(simulator.CPU._testCond("_C/ULT"), true);
-    T.assertEquals(simulator.CPU._testCond("_NC/UGE"), false);
+    T.assertEquals(simulator.CPU._testCond("_C/UGE"), true);
+    T.assertEquals(simulator.CPU._testCond("_NC/ULT"), false);
     T.assertEquals(simulator.CPU._testCond("_V"), false);
     T.assertEquals(simulator.CPU._testCond("_NV"), true);
     T.assertEquals(simulator.CPU._testCond("_Z/EQ"), true);


### PR DESCRIPTION
As per https://github.com/izuzak/FRISCjs/pull/15, the old implementation was based on these definitions:

ULE - C=1 or Z=1
UGT - C=0 and Z=0
ULT - C=1
UGE - C=0

However, the correct definitions are:

ULE - C=0 or Z=1
UGT - C=1 and Z=0
ULT - C=0
UGE - C=1

cc @ibudiselic for 👀 